### PR TITLE
Fix VPC CIDR and Postgres SG typo

### DIFF
--- a/terraform_code/modules/networking/security_groups/main.tf
+++ b/terraform_code/modules/networking/security_groups/main.tf
@@ -331,7 +331,7 @@ resource "aws_security_group" "mysql_target_sg" {
   }
 }
 
-resource "aws_security_group" "posgresql_target_sg" {
+resource "aws_security_group" "postgresql_target_sg" {
   name        = "${var.team_name}-postgresql-sg"
   description = "Allow PostgreSQL from private subnets only"
   vpc_id      = var.vpc_id

--- a/terraform_code/modules/networking/security_groups/outputs.tf
+++ b/terraform_code/modules/networking/security_groups/outputs.tf
@@ -76,5 +76,5 @@ output "mysql_target_sg_id" {
 
 output "postgresql_target_sg_id" {
   description = "The name of the security group"
-  value = aws_security_group.posgresql_target_sg.id
+  value = aws_security_group.postgresql_target_sg.id
 }

--- a/terraform_code/modules/networking/vpc/main.tf
+++ b/terraform_code/modules/networking/vpc/main.tf
@@ -1,6 +1,6 @@
 # VPC
 resource "aws_vpc" "main" {
-  cidr_block           = "192.168.0.0/16"
+  cidr_block           = var.vpc_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
 


### PR DESCRIPTION
## Summary
- use the provided `vpc_cidr` variable when creating the VPC
- correct the misspelt `postgresql_target_sg` name in security group module

## Testing
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643824998083328a1866cc3a39c8f4