### PR TITLE
Add detailed READMEs with usage examples

### DIFF
--- a/terraform_code/README.md
+++ b/terraform_code/README.md
@@ -1,0 +1,11 @@
+# Terraform Code
+
+This directory holds the main configuration used to deploy the lab's AWS environment. New IAM professionals can explore how modules are composed to provision networking, compute, and security resources.
+
+## Usage
+1. Configure your AWS credentials with sufficient permissions for IAM and resource creation.
+2. Run `terraform init` to download the required providers.
+3. Review the variables in `terraform.tfvars` and adjust values for your environment.
+4. Execute `terraform apply` to create the infrastructure.
+
+The `modules` folder contains reusable building blocks referenced by this top level configuration.

--- a/terraform_code/modules/README.md
+++ b/terraform_code/modules/README.md
@@ -1,0 +1,15 @@
+# Terraform Modules
+
+This directory contains self‑contained Terraform modules that provide networking, security, and compute resources. Each module can be reused across environments and is documented in its own subfolder.
+
+## Usage
+Reference a module from your configuration using the `module` block. Example:
+
+```hcl
+module "vpc" {
+  source = "./modules/networking/vpc"
+  # see variables.tf in the module for available inputs
+}
+```
+
+Modules help you organize infrastructure code and reduce duplication, which is especially helpful when managing IAM permissions across multiple resources.

--- a/terraform_code/modules/infrastructure/README.md
+++ b/terraform_code/modules/infrastructure/README.md
@@ -1,0 +1,14 @@
+# Infrastructure Modules
+
+These modules provision the core resources of the lab including EC2 instances, RDS databases and Secrets Manager secrets. They are intended to be composed by the root configuration or other modules.
+
+## Usage
+Declare one of the submodules in your configuration and pass the required variables. For example:
+
+```hcl
+module "dc" {
+  source = "./modules/infrastructure/ec2_instances/dc"
+}
+```
+
+New IAM professionals should review the IAM policies attached to each module to understand the permissions required for provisioning.

--- a/terraform_code/modules/infrastructure/aws_sm_secrets/README.md
+++ b/terraform_code/modules/infrastructure/aws_sm_secrets/README.md
@@ -1,0 +1,14 @@
+# AWS Secrets Manager Module
+
+This module creates secrets in AWS Secrets Manager for storing credentials such as the domain join account. Use it to keep passwords out of your configuration files.
+
+## Usage
+```hcl
+module "aws_sm_secrets" {
+  source                 = "./modules/infrastructure/aws_sm_secrets"
+  domain_join_username   = "CORP\\joinuser"
+  domain_join_password   = "StrongPassword!"        # consider using variables marked sensitive
+  domain_join_secret_name = "corp/joinuser"
+}
+```
+Ensure the IAM user running Terraform has permissions to create and update secrets (`secretsmanager:*`).

--- a/terraform_code/modules/infrastructure/ec2_instances/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/README.md
@@ -1,0 +1,15 @@
+# EC2 Instance Modules
+
+This folder contains submodules that launch different EC2 instances used by the lab (domain controllers, target hosts, and automation tooling). Each module configures IAM roles, security groups and user data as needed.
+
+## Usage
+Include the specific instance module you require. A simplified example:
+
+```hcl
+module "public_server" {
+  source      = "./modules/infrastructure/ec2_instances/ec2_public_server"
+  key_name    = module.key_pair.key_name
+  vpc_subnet_id = module.vpc.public_subnet_id
+}
+```
+Ensure your IAM user has `ec2:*` permissions and the ability to pass any roles created for the instance.

--- a/terraform_code/modules/infrastructure/ec2_instances/automation_station/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/automation_station/README.md
@@ -1,0 +1,12 @@
+# Automation Station Module
+
+Provisions an EC2 instance preconfigured with Jenkins and Ansible for running automation tasks. The instance can pull code from version control and execute playbooks against the lab environment.
+
+## Usage
+```hcl
+module "automation_station" {
+  source  = "./modules/infrastructure/ec2_instances/automation_station"
+  subnet_id = module.vpc.private_subnet_id
+}
+```
+The IAM role assigned to this instance should allow it to assume other roles or access services as required by your automation workflows.

--- a/terraform_code/modules/infrastructure/ec2_instances/aws_sia_connector/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/aws_sia_connector/README.md
@@ -1,0 +1,12 @@
+# AWS SIA Connector Module
+
+Deploys the Secure Infrastructure Access (SIA) connector used for identity-aware access to the lab. The instance registers with the SIA service and must be able to reach the internet for onboarding.
+
+## Usage
+```hcl
+module "sia_connector" {
+  source = "./modules/infrastructure/ec2_instances/aws_sia_connector"
+  subnet_id = module.vpc.private_subnet_id
+}
+```
+Ensure that the IAM role attached to the instance allows the necessary SIA API calls and that outbound connectivity is permitted by the security group.

--- a/terraform_code/modules/infrastructure/ec2_instances/cyberark_connectors/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/cyberark_connectors/README.md
@@ -1,0 +1,12 @@
+# CyberArk Connectors Module
+
+Creates EC2 instances that run CyberArk connector software. These connectors integrate the lab environment with external CyberArk services for credential management.
+
+## Usage
+```hcl
+module "cyberark_connectors" {
+  source  = "./modules/infrastructure/ec2_instances/cyberark_connectors"
+  subnet_id = module.vpc.private_subnet_id
+}
+```
+Grant the attached IAM role only the permissions required for the CyberArk connector to operate, following the principle of least privilege.

--- a/terraform_code/modules/infrastructure/ec2_instances/dc/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/dc/README.md
@@ -1,0 +1,12 @@
+# Domain Controller Module
+
+This module provisions a Windows Server instance configured to act as the lab's Active Directory domain controller. It can also create the necessary IAM role to allow the instance to join other servers to the domain.
+
+## Usage
+```hcl
+module "dc" {
+  source    = "./modules/infrastructure/ec2_instances/dc"
+  subnet_id = module.vpc.private_subnet_id
+}
+```
+Ensure your IAM user can create service-linked roles and `ec2:*` resources when applying this module.

--- a/terraform_code/modules/infrastructure/ec2_instances/ec2_public_server/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/ec2_public_server/README.md
@@ -1,0 +1,13 @@
+# Public Server Module
+
+Launches an EC2 instance with a public IP address. Useful for demo servers or jump hosts. The instance is placed in a public subnet and optionally associated with an IAM role for management access.
+
+## Usage
+```hcl
+module "public_server" {
+  source     = "./modules/infrastructure/ec2_instances/ec2_public_server"
+  key_name   = module.key_pair.key_name
+  subnet_id  = module.vpc.public_subnet_id
+}
+```
+A security group allowing inbound access should also be attached. The deploying IAM identity requires `ec2:*` permissions.

--- a/terraform_code/modules/infrastructure/ec2_instances/targets/README.md
+++ b/terraform_code/modules/infrastructure/ec2_instances/targets/README.md
@@ -1,0 +1,13 @@
+# Target Hosts Module
+
+Deploys EC2 instances that act as target machines within the lab. Targets can be Windows or Linux and typically host demo applications used during training.
+
+## Usage
+```hcl
+module "targets" {
+  source = "./modules/infrastructure/ec2_instances/targets"
+  instance_count = 2
+  subnet_id      = module.vpc.private_subnet_id
+}
+```
+An IAM role with `ec2:*` permissions is required to launch and configure these instances.

--- a/terraform_code/modules/infrastructure/rds/README.md
+++ b/terraform_code/modules/infrastructure/rds/README.md
@@ -1,0 +1,16 @@
+# RDS Modules
+
+These modules deploy Amazon RDS databases used by the lab. Submodules are provided for MySQL and PostgreSQL engines.
+
+## Usage
+Choose the appropriate engine and include the module in your configuration:
+
+```hcl
+module "mysql" {
+  source = "./modules/infrastructure/rds/mysql"
+  identifier = "my-lab-db"
+  # see variables.tf for more options
+}
+```
+
+Provisioning RDS requires IAM privileges for `rds:*`. Database credentials should be stored securely, for example using the Secrets Manager module.

--- a/terraform_code/modules/infrastructure/rds/mysql/README.md
+++ b/terraform_code/modules/infrastructure/rds/mysql/README.md
@@ -1,0 +1,13 @@
+# MySQL RDS Module
+
+This module spins up an Amazon RDS MySQL instance. It exposes variables for storage size, instance class, username and password.
+
+## Usage
+```hcl
+module "mysql" {
+  source            = "./modules/infrastructure/rds/mysql"
+  db_subnet_group_name = module.db_subnet_group.name
+  vpc_security_group_ids = [module.db_sg.id]
+}
+```
+Refer to `variables.tf` for a full list of configuration options. The IAM user executing Terraform must have permissions to create RDS instances.

--- a/terraform_code/modules/infrastructure/rds/postgresql/README.md
+++ b/terraform_code/modules/infrastructure/rds/postgresql/README.md
@@ -1,0 +1,13 @@
+# PostgreSQL RDS Module
+
+Creates an Amazon RDS PostgreSQL instance for the lab. Key settings such as instance class, database name and credentials are configurable through module variables.
+
+## Usage
+```hcl
+module "postgresql" {
+  source = "./modules/infrastructure/rds/postgresql"
+  identifier = "lab-postgres"
+  db_subnet_group_name = module.db_subnet_group.name
+}
+```
+Make sure your IAM policies allow `rds:*` actions when applying this module.

--- a/terraform_code/modules/networking/README.md
+++ b/terraform_code/modules/networking/README.md
@@ -1,0 +1,12 @@
+# Networking Modules
+
+This section contains modules that configure the network layout for the lab. Modules are provided for creating the VPC, database subnet groups and security groups.
+
+## Usage
+Include the required networking modules in your root configuration:
+```hcl
+module "vpc" {
+  source = "./modules/networking/vpc"
+}
+```
+Proper networking design is key for controlling which IAM roles and services can communicate with one another.

--- a/terraform_code/modules/networking/db_subnet_group/README.md
+++ b/terraform_code/modules/networking/db_subnet_group/README.md
@@ -1,0 +1,12 @@
+# DB Subnet Group Module
+
+Defines a collection of subnets to be used for Amazon RDS instances. The module ensures your database is deployed across multiple Availability Zones for redundancy.
+
+## Usage
+```hcl
+module "db_subnet_group" {
+  source        = "./modules/networking/db_subnet_group"
+  subnet_ids    = module.vpc.private_subnet_ids
+}
+```
+Your IAM user must have permission to manage RDS resources to create the subnet group.

--- a/terraform_code/modules/networking/security_groups/README.md
+++ b/terraform_code/modules/networking/security_groups/README.md
@@ -1,0 +1,11 @@
+# Security Groups Module
+
+Contains reusable security group definitions for controlling inbound and outbound traffic. Apply this module to enforce network policies around your EC2 instances and RDS databases.
+
+## Usage
+```hcl
+module "security_groups" {
+  source = "./modules/networking/security_groups"
+}
+```
+Modify `variables.tf` to adjust default ports or create additional groups.

--- a/terraform_code/modules/networking/vpc/README.md
+++ b/terraform_code/modules/networking/vpc/README.md
@@ -1,0 +1,12 @@
+# VPC Module
+
+This module builds the Virtual Private Cloud (VPC) that hosts the lab resources. It defines public and private subnets, route tables and internet gateways.
+
+## Usage
+```hcl
+module "vpc" {
+  source     = "./modules/networking/vpc"
+  vpc_cidr   = "10.0.0.0/16"
+}
+```
+Modify `variables.tf` to customize subnet CIDR blocks or Availability Zones as needed.

--- a/terraform_code/modules/s3_bucket/README.md
+++ b/terraform_code/modules/s3_bucket/README.md
@@ -1,0 +1,12 @@
+# S3 Bucket Module
+
+Creates an S3 bucket for storing lab artifacts such as installation media or Terraform state. The bucket is configured with server-side encryption and private access by default.
+
+## Usage
+```hcl
+module "s3_bucket" {
+  source = "./modules/s3_bucket"
+  bucket_name = "my-lab-bucket"
+}
+```
+The IAM principal running Terraform must have permission to manage S3 buckets (`s3:*`). Consider enabling versioning if storing state files.

--- a/terraform_code/modules/security/README.md
+++ b/terraform_code/modules/security/README.md
@@ -1,0 +1,13 @@
+# Security Modules
+
+Security related modules for IAM roles, policies and key pairs. Using these modules ensures that access to AWS resources in the lab follows best practices.
+
+## Usage
+Invoke the required IAM role or key module from your configuration. Example:
+
+```hcl
+module "ec2_asm_role" {
+  source = "./modules/security/iam_roles/ec2_asm_role"
+}
+```
+Before applying, verify that your IAM identity has the ability to create roles and policies.

--- a/terraform_code/modules/security/iam_roles/README.md
+++ b/terraform_code/modules/security/iam_roles/README.md
@@ -1,0 +1,11 @@
+# IAM Role Modules
+
+These modules define IAM roles and associated policies that can be attached to EC2 instances or used by AWS services. Centralizing role definitions simplifies permission management for new practitioners.
+
+## Usage
+```hcl
+module "jenkins_server_role" {
+  source = "./modules/security/iam_roles/jenkins_server_role"
+}
+```
+Review each role's `policies.tf` file for details on the permissions granted.

--- a/terraform_code/modules/security/iam_roles/ec2_asm_role/README.md
+++ b/terraform_code/modules/security/iam_roles/ec2_asm_role/README.md
@@ -1,0 +1,11 @@
+# EC2 Secrets Manager Role
+
+Provides an IAM role that allows EC2 instances to read secrets from AWS Secrets Manager. Attach this role to instances that need access to stored credentials.
+
+## Usage
+```hcl
+module "ec2_asm_role" {
+  source = "./modules/security/iam_roles/ec2_asm_role"
+}
+```
+After creation, reference the role's ARN when launching your EC2 instance.

--- a/terraform_code/modules/security/iam_roles/jenkins_server_role/README.md
+++ b/terraform_code/modules/security/iam_roles/jenkins_server_role/README.md
@@ -1,0 +1,11 @@
+# Jenkins Server Role
+
+Defines an IAM role for the Jenkins automation server. The role allows Jenkins to manage EC2 instances and access Secrets Manager for pulling credentials during build steps.
+
+## Usage
+```hcl
+module "jenkins_server_role" {
+  source = "./modules/security/iam_roles/jenkins_server_role"
+}
+```
+After applying, attach the role to the Jenkins EC2 instance so it can perform deployments and automation tasks.

--- a/terraform_code/modules/security/iam_roles/secrets_hub_onboarding_role/README.md
+++ b/terraform_code/modules/security/iam_roles/secrets_hub_onboarding_role/README.md
@@ -1,0 +1,11 @@
+# Secrets Hub Onboarding Role
+
+Creates a role used to enroll the lab account with AWS Secrets Hub. The role grants permissions required for the onboarding process such as creating resource shares and managing secrets.
+
+## Usage
+```hcl
+module "secrets_hub_onboarding_role" {
+  source = "./modules/security/iam_roles/secrets_hub_onboarding_role"
+}
+```
+Only administrators performing the onboarding should assume this role.

--- a/terraform_code/modules/security/key_pair/README.md
+++ b/terraform_code/modules/security/key_pair/README.md
@@ -1,0 +1,12 @@
+# Key Pair Module
+
+Handles creation or import of an SSH key pair used for connecting to EC2 instances. By default a new key is generated and stored locally.
+
+## Usage
+```hcl
+module "key_pair" {
+  source = "./modules/security/key_pair"
+  key_name = "lab-key"
+}
+```
+Keep the private key secure and restrict permissions to users who require SSH access.


### PR DESCRIPTION
## Summary
- expand Terraform documentation across all module folders
- include usage examples and IAM-focused explanations

## Testing
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864388263348328a7ec43d53847559b